### PR TITLE
Add empty bibs/annos folder and fix typo in compile.sh

### DIFF
--- a/bibs/annos/.gitignore
+++ b/bibs/annos/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/compile.sh
+++ b/compile.sh
@@ -8,7 +8,7 @@ cd bibs # outputs files into annos folder below bibs
 awk -f x-anno.awk *.bib
 
 # regenerate the contrib-cites map
-head -n 1  ../contrib-cites.csv > annos/_.csv #grap the header
+head -n 1  ../contrib-cites.csv > annos/_.csv #grep the header
 cat annos/*.csv > ../contrib-cites.csv #put all into one file
 rm annos/*.csv #clean up
 cd ..


### PR DESCRIPTION
I added the `bibs/annos` folder in the tree so that the compile script works properly out of the box.